### PR TITLE
Update tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "rootDir": "src",
     "strict": true,
     "strictNullChecks": false,
-    "target": "es2017",
+    "target": "es2018",
     "types": []
   },
   "include": ["src/*"]


### PR DESCRIPTION
The  extension fails to install on `Jupyter-Lab version 3.5.2` with: 
```
  error: subprocess-exited-with-error
  
  × Building wheel for nersc-refresh-announcements (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [44 lines of output]
      yarn install v1.21.1
      info No lockfile found.
      warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
      [1/4] Resolving packages...
      warning @jupyterlab/application > @jupyterlab/apputils > url > querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
      warning @jupyterlab/application > @jupyterlab/ui-components > @blueprintjs/core > popper.js@1.16.1: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
      warning @jupyterlab/application > @jupyterlab/ui-components > @blueprintjs/core > react-popper > popper.js@1.16.1: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
      warning @jupyterlab/builder > terser-webpack-plugin > cacache > @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
      [2/4] Fetching packages...
      warning @blueprintjs/core@3.54.0: Invalid bin entry for "upgrade-blueprint-2.0.0-rename" (in "@blueprintjs/core").
      warning @blueprintjs/core@3.54.0: Invalid bin entry for "upgrade-blueprint-3.0.0-rename" (in "@blueprintjs/core").
      [3/4] Linking dependencies...
      warning "@jupyterlab/application > @jupyterlab/ui-components@3.6.1" has unmet peer dependency "react@^17.0.1".
      warning "@jupyterlab/application > @lumino/coreutils@1.12.1" has unmet peer dependency "crypto@1.0.1".
      warning "@jupyterlab/application > @jupyterlab/docregistry > @jupyterlab/codemirror > y-codemirror@3.0.1" has unmet peer dependency "yjs@^13.5.17".
      [4/4] Building fresh packages...
      success Saved lockfile.
      Done in 24.86s.
      yarn run v1.21.1
      $ jlpm run clean && jlpm run build:lib && jlpm run build:labextension
      $ jlpm run clean:lib
      $ rimraf lib tsconfig.tsbuildinfo
      $ tsc
      node_modules/@jupyterlab/services/lib/event/index.d.ts(89,52): error TS2583: Cannot find name 'AsyncIterable'. Do you need to change your target library? Try changing the `lib` compiler option to 'es2018' or later.
      error Command failed with exit code 1.
      info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
      error Command failed with exit code 1.
      info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
      Traceback (most recent call last):
        File "/opt/conda/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 351, in <module>
          main()
        File "/opt/conda/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 333, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/opt/conda/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 249, in build_wheel
          return _build_backend().build_wheel(wheel_directory, config_settings,
        File "/tmp/pip-build-env-7zl5nk7z/overlay/lib/python3.10/site-packages/jupyter_packaging/build_api.py", line 22, in build_wheel
          builder()
        File "/tmp/pip-build-env-7zl5nk7z/overlay/lib/python3.10/site-packages/jupyter_packaging/setupbase.py", line 233, in builder
          run(npm_cmd + ["run", build_cmd], cwd=node_package)
        File "/tmp/pip-build-env-7zl5nk7z/overlay/lib/python3.10/site-packages/jupyter_packaging/setupbase.py", line 297, in run
          return subprocess.check_call(cmd, **kwargs)
        File "/opt/conda/lib/python3.10/subprocess.py", line 369, in check_call
          raise CalledProcessError(retcode, cmd)
      subprocess.CalledProcessError: Command '['/tmp/pip-build-env-7zl5nk7z/overlay/bin/jlpm', 'run', 'build:prod']' returned non-zero exit status 1.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for nersc-refresh-announcements
ERROR: Could not build wheels for nersc-refresh-announcements, which is required to install pyproject.toml-based projects

```